### PR TITLE
fix: in case of a missing original transaction the restore function crashed

### DIFF
--- a/IAPHelper/IAPHelper.m
+++ b/IAPHelper/IAPHelper.m
@@ -140,7 +140,12 @@
     
     
     [self recordTransaction: transaction];
-    [self provideContent: transaction.originalTransaction.payment.productIdentifier];
+    
+    if (transaction.originalTransaction)
+        [self provideContent: transaction.originalTransaction.payment.productIdentifier];
+    else
+        [self provideContent: transaction.payment.productIdentifier];
+
     [[SKPaymentQueue defaultQueue] finishTransaction: transaction];
 
     if(_buyProductCompleteBlock!=nil)
@@ -223,7 +228,10 @@
             case SKPaymentTransactionStateRestored:
             {
                 [self recordTransaction: transaction];
-                [self provideContent: transaction.originalTransaction.payment.productIdentifier];
+	        if (transaction.originalTransaction)
+                    [self provideContent: transaction.originalTransaction.payment.productIdentifier];
+                else
+                    [self provideContent: transaction.payment.productIdentifier];
             }
             default:
                 break;


### PR DESCRIPTION
In my case (maybe because of the lots of auto renewable subscriptions I've generated through testing) there were a few cases where on restore the transction's originalTransaction was nil and it crashed when it tried to add a nil product identifier to an NSSet.
I've fixed this issue by using the restored transaction's product identifier instead of the original transaction. I'm not 100% sure that this is the best way to solve this issue but it solved it permanently.
